### PR TITLE
Add example pipeline notebook

### DIFF
--- a/example_pipeline.ipynb
+++ b/example_pipeline.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Example Analysis Pipeline"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["This notebook demonstrates a simple pipeline using the `community_collection` package."]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 1. Sample data"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "sample_messages = [\n",
+    "    {\"id\": 1, \"timestamp\": \"2024-01-01\", \"content\": \"Hello world from OpenAI!\", \"embeds\": []},\n",
+    "    {\"id\": 2, \"timestamp\": \"2024-01-02\", \"content\": \"Codex generates code and text.\", \"embeds\": []},\n",
+    "    {\"id\": 3, \"timestamp\": \"2024-01-03\", \"content\": \"Artificial intelligence is transforming research.\", \"embeds\": []}\n",
+    "]\n",
+    "df = pd.DataFrame(sample_messages)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 2. Parse messages"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from community_collection import parse_message, create_combined_content\n",
+    "parsed = [parse_message(m) for m in sample_messages]\n",
+    "messages_df = pd.DataFrame(parsed)\n",
+    "messages_df = create_combined_content(messages_df)\n",
+    "messages_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 3. Add NLP features"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from community_collection import add_ner_columns, add_nounchunk_columns\n",
+    "messages_df = add_ner_columns(messages_df, 'combined_content', model='en_core_web_sm')\n",
+    "messages_df = add_nounchunk_columns(messages_df, 'combined_content', model='en_core_web_sm')\n",
+    "messages_df[['combined_content_entities', 'combined_content_noun_chunks']].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 4. Chunk and vectorise"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from community_collection import chunk, vectorise\n",
+    "chunks = chunk(messages_df['combined_content'].tolist(), model='intfloat/multilingual-e5-small', size=50)\n",
+    "chunk_vectors = vectorise(chunks, model='intfloat/multilingual-e5-small', batch_size=8, progress=False)\n",
+    "chunk_vectors[:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 5. Reduce dimensions and cluster"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from community_collection import reduce_vectors, cluster\n",
+    "cluster_vecs, map_vecs = reduce_vectors(chunk_vectors)\n",
+    "labels = cluster(cluster_vecs)\n",
+    "labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 6. Topic modelling"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from community_collection import use_bertopic_with_custom_vectors\n",
+    "model, topics = use_bertopic_with_custom_vectors(chunk_vectors, messages_df['combined_content'].tolist(), n_topics=3)\n",
+    "print(topics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["This pipeline processes a small set of messages, generates embeddings, clusters them and assigns topics using BERTopic."]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,5 @@ community_collection/
 ```
 
 Import functions from these modules to build your own scripts.
+
+A small example pipeline is provided in `example_pipeline.ipynb` to illustrate how the package can be used.


### PR DESCRIPTION
## Summary
- create `example_pipeline.ipynb` demonstrating message parsing, NLP, vectorization, clustering and topic modelling with the package
- note the example notebook in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dad77ff48323aea76506823f2239